### PR TITLE
Coerce 'job' value in Lua script to a string

### DIFF
--- a/src/System/Hworker.hs
+++ b/src/System/Hworker.hs
@@ -277,7 +277,7 @@ worker hw =
      r <- R.runRedis (hworkerConnection hw) $
             R.eval "local job = redis.call('rpop',KEYS[1])\n\
                    \if job ~= nil then\n\
-                   \  redis.call('hset', KEYS[2], job, ARGV[1])\n\
+                   \  redis.call('hset', KEYS[2], tostring(job), ARGV[1])\n\
                    \  return job\n\
                    \else\n\
                    \  return nil\n\


### PR DESCRIPTION
I’m not too familiar with Lua scripting so I'm unsure of why this is, but it appears that versions of Redis after 2.8 can’t infer the type of `job` in the first Lua script. I've found that coercing it to a string using the `tostring` function does get the example program to work on Redis 5.0. However, I have not tested it on any of the other major versions after 2.8. 

Fixes #2 